### PR TITLE
fix: No more "missing act" warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3852,9 +3852,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "http://claim-master.prodlb.travp.net/repo/repository/ClaimNPMGroupLobM/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "0.0.0-semantically-released",
+      "resolved": "https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react",
+      "integrity": "sha512-5/baWe6o/GHC9orcx9A/sCTyfUcrQkFmRKDUyZZf0wqHpY5ngH3NcjG09l/iA8YKafHXYh5ikaxQ6WZm/0MCFg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -3862,7 +3862,7 @@
         "@types/react-dom": "^18.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -20629,9 +20629,8 @@
       }
     },
     "@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "http://claim-master.prodlb.travp.net/repo/repository/ClaimNPMGroupLobM/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react",
+      "integrity": "sha512-5/baWe6o/GHC9orcx9A/sCTyfUcrQkFmRKDUyZZf0wqHpY5ngH3NcjG09l/iA8YKafHXYh5ikaxQ6WZm/0MCFg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Testing https://github.com/testing-library/react-testing-library/pull/1137
